### PR TITLE
Fix bug in deftemplate; 'list should be `list

### DIFF
--- a/src/main/clojure/clojure/tools/macro.clj
+++ b/src/main/clojure/clojure/tools/macro.clj
@@ -251,7 +251,7 @@
   (let [param-map (for [p params] (list (list 'quote p) (gensym)))
         template-params (vec (map second param-map))
         param-map (vec (apply concat param-map))
-        expansion (list 'list (list 'quote `symbol-macrolet) param-map
+        expansion (list `list (list 'quote `symbol-macrolet) param-map
                         (list 'quote (cons 'do forms)))]
     `(defmacro ~name ~template-params ~expansion)))
 


### PR DESCRIPTION
It seems to me that the `'list` in deftemplate should use syntax quote, otherwise having list redefined will break deftemplate.

EDIT: Sorry, saw CONTRIBUTING.md after posting this. Do with it what you want.